### PR TITLE
Database and Query Files

### DIFF
--- a/Resources/SQL/query.sql
+++ b/Resources/SQL/query.sql
@@ -1,0 +1,71 @@
+CREATE TABLE clean (
+	appid INT NOT NULL,
+	name VARCHAR NOT NULL,
+	release_date DATE NOT NULL,
+	english BOOL NOT NULL,
+	developer VARCHAR NOT NULL,
+	publisher VARCHAR NOT NULL,
+	platforms VARCHAR(40) NOT NULL,
+	required_age INT NOT NULL,
+	categories VARCHAR NOT NULL,
+	genres VARCHAR NOT NULL,
+	steamspy_tags VARCHAR NOT NULL,
+	achievements INT NOT NULL,
+	positive_ratings INT NOT NULL,
+	negative_ratings INT NOT NULL,
+	average_playtime INT NOT NULL,
+	median_playtime INT NOT NULL,
+	owners VARCHAR(100) NOT NULL,
+	price FLOAT NOT NULL,
+	PRIMARY KEY (appid)
+);
+
+ALTER TABLE clean
+RENAME COLUMN appid TO steam_appid;
+
+SELECT * FROM clean;
+
+CREATE TABLE descriptions (
+	steam_appid INT NOT NULL,
+	detailed_description VARCHAR NOT NULL,
+	about_the_game VARCHAR NOT NULL,
+	short_description VARCHAR NOT NULL,
+	PRIMARY KEY (steam_appid)
+);
+
+SELECT * FROM descriptions;
+
+CREATE TABLE media (
+	steam_appid INT NOT NULL,
+	header_image VARCHAR NOT NULL,
+	screenshots VARCHAR NOT NULL,
+	background VARCHAR NOT NULL,
+	movies VARCHAR NOT NULL,
+	PRIMARY KEY (steam_appid)
+);
+
+SELECT * FROM media;
+
+SELECT cl.steam_appid,
+	cl.name,
+	cl.price,
+	cl.release_date,
+	cl.developer,
+	cl.publisher,
+	me.header_image,
+	me.background,
+	de.about_the_game,
+	de.short_description
+INTO final
+FROM media AS me
+INNER JOIN clean AS cl
+ON cl.steam_appid = me.steam_appid
+INNER JOIN descriptions AS de
+ON cl.steam_appid = de.steam_appid;
+
+ALTER TABLE final
+ADD COLUMN linear_score FLOAT,
+ADD COLUMN random_forest_score FLOAT;
+
+
+SELECT * FROM final;


### PR DESCRIPTION
Database should be included to import into your own local servers/schemas.

Query file was included as well, should be able to open in pgAdmin.

All datafiles we should be using as the base files were imported as tables:

**steam_cleaned as clean**:

 - steam_appid (Changed from appid to be compatible with our other datasets)
 - name
 - release_date
 - english
 - developer
 - publisher
 - platforms
 - required_age
 - categories
 - genres
 - steamspy_tags
 - achievements
 - positive_ratings
 - negative_ratings
 - average_playtime
 - median_playtime
 - owners
 - price

**steam_description_data as descriptions**:

 - steam_appid
 - detailed_description
 - about_the_game
 - short_description

**steam_media_data as media**:

 - steam_appid
 - header_image
 - screenshots
 - background
 - movies

The base tables were them joined into a new table called 'final', which should contain all the data needed for presentation purposes.

**The following elements are in 'final'**:

 - steam_appid
 - name
 - price
 - release_date
 - developer
 - publisher
 - header_image
 - background
 - about_the_game
 - short_description
 - linear_score (_subject to change_)
 - random_forest_score (_subject to change_)

